### PR TITLE
Bug 2748: generate screenshot even with rich icon

### DIFF
--- a/extension/mozillaonline/parent/ext-chinaNewtab.js
+++ b/extension/mozillaonline/parent/ext-chinaNewtab.js
@@ -472,20 +472,6 @@ this.topSites = {
     }
   },
 
-  async cacheExtraScreenshot(index) {
-    if (!this.feed) {
-      return;
-    }
-
-    let links = await this.feed.pinnedCache.request();
-    let link = links[index];
-    if (!link) {
-      return;
-    }
-
-    await this.feed._fetchScreenshot(link, link.url);
-  },
-
   convertSite(site) {
     let customScreenshotURL = site.attachment &&
       site.attachment.location &&


### PR DESCRIPTION
In our newtab experience, topsites are displayed as compact cards, instead of squares in upstream about:newtab. As a result, we prefer a site's screenshot even when a large enough rich icon is available.

See MozillaOnline/newtab-web@dcdcd8d4 for the web-hosted side of the change. However, triggering generation of such screenshots for real was left unimplemented in the extension side, with less than 2% of all topsites affected.

This commit implements the extension fix. Let me know if you need clarification on more details.

Thanks!