### PR TITLE
Fx 86 compat fixes

### DIFF
--- a/extension/mozillaonline/parent/ext-chinaNewtab.js
+++ b/extension/mozillaonline/parent/ext-chinaNewtab.js
@@ -231,8 +231,6 @@ this.activityStreamHack = {
     } else {
       aboutNewTabService.newTabURL = NEWTAB_URL;
     }
-    // See https://bugzil.la/1184701,1625609
-    Services.prefs.getDefaultBranch("browser.tabs.remote.").setBoolPref("separatePrivilegedContentProcess", false);
   },
 
   setPref(key, val) {


### PR DESCRIPTION
With https://bugzil.la/1513680 landed in Fx 86, when using the current version of this extension, search is broken in both our web based newtab and `about:privatebrowsing`.

