### PR TITLE
Bug 2810: part 3, followup fix

### DIFF
--- a/extension/legacy/ChinaNewtabContentSearchParent.jsm
+++ b/extension/legacy/ChinaNewtabContentSearchParent.jsm
@@ -27,7 +27,12 @@ XPCOMUtils.defineLazyGetter(this, "ContentSearch", () => {
   const { ContentSearch } = ChromeUtils.import(contentSearchJSM);
   if (!ContentSearch.receiveMessage) {
     ContentSearch._reply = (browser, type, data) => {
-      if (browser.remoteType === "privilegedabout") {
+      if (
+        browser.remoteType === "privilegedabout" ||
+        // `about:privatebrowsing` is not loaded in `privilegedabout` process
+        // until Fx 86, see https://bugzil.la/1687359
+        browser.currentURI.prePath === "about:"
+      ) {
         browser.sendMessageToActor(type, data, "ContentSearch");
       } else if (
         browser.remoteType === "web" &&


### PR DESCRIPTION
Followup of #11.

In case `about:privatebrowsing` etc. is not loaded in `privilegedabout` process, like before Fx 86 (see https://bugzil.la/1687359), or the pref was flipped (by a previous version of this extension, after extension update but before Fx restart).

Thanks!