### PR TITLE
Bug 2820: ASRouter switched to JSWindowActors on Fx 84+

### DIFF
--- a/extension/legacy/ChinaNewtabASRouterChild.jsm
+++ b/extension/legacy/ChinaNewtabASRouterChild.jsm
@@ -1,0 +1,14 @@
+/* vim: set ts=2 sw=2 sts=2 et tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["ChinaNewtabASRouterChild"];
+
+const { ASRouterChild } = ChromeUtils.import(
+  "resource:///actors/ASRouterChild.jsm"
+);
+
+class ChinaNewtabASRouterChild extends ASRouterChild {}

--- a/extension/legacy/ChinaNewtabASRouterParent.jsm
+++ b/extension/legacy/ChinaNewtabASRouterParent.jsm
@@ -1,0 +1,15 @@
+/* vim: set ts=2 sw=2 sts=2 et tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["ChinaNewtabASRouterParent"];
+
+const { ASRouterParent } = ChromeUtils.import(
+  "resource:///actors/ASRouterParent.jsm"
+);
+
+class ChinaNewtabASRouterParent extends ASRouterParent {}
+

--- a/extension/mozillaonline/parent/ext-chinaNewtab.js
+++ b/extension/mozillaonline/parent/ext-chinaNewtab.js
@@ -314,6 +314,42 @@ this.activityStreamHack = {
   },
 };
 
+this.asRouter = {
+  init() {
+    // Available since Fx 84, see https://bugzil.la/1614465
+    if (Services.vc.compare(Services.appinfo.version, "84.0") < 0) {
+      return;
+    }
+
+    try {
+      ChromeUtils.registerWindowActor("ChinaNewtabASRouter", {
+        parent: {
+          moduleURI: `resource://${RESOURCE_HOST}/ChinaNewtabASRouterParent.jsm`,
+        },
+        child: {
+          moduleURI: `resource://${RESOURCE_HOST}/ChinaNewtabASRouterChild.jsm`,
+          events: {
+            DOMWindowCreated: {},
+          },
+        },
+        matches:  [
+          "https://newtab.firefoxchina.cn/*",
+        ],
+      });
+    } catch (ex) {
+      console.error(ex);
+    }
+  },
+
+  uninit() {
+    try {
+      ChromeUtils.unregisterWindowActor("ChinaNewtabASRouter");
+    } catch (ex) {
+      console.error(ex);
+    }
+  },
+};
+
 this.chinaNewtabFeed = {
   initialized: false,
 
@@ -869,6 +905,7 @@ this.chinaNewtab = class extends ExtensionAPI {
 
     activityStreamHack.init(extension);
 
+    asRouter.init();
     contentSearch.init(extension);
     ntpColors.init();
     searchPlugins.init();
@@ -877,6 +914,7 @@ this.chinaNewtab = class extends ExtensionAPI {
   onShutdown() {
     ntpColors.uninit();
     contentSearch.uninit();
+    asRouter.uninit();
 
     activityStreamHack.uninit();
 


### PR DESCRIPTION
Essentially make it possible to show simple snippets (if any targets `CN` region or `zh-CN` locale, which rarely happens) in our forked newtab. And in reality, mostly necessary to suppress an error message in the web console.

Thanks!