### PR TITLE
Bug 2819: turn on DiscoveryStream

### DIFF
--- a/extension/legacy/ChinaNewtabFeed.jsm
+++ b/extension/legacy/ChinaNewtabFeed.jsm
@@ -3,18 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const EVENTS = [
-  "BLOCK",
-  "CLICK",
-  "MENU_COLLAPSE",
-  "MENU_EXPAND",
-  "MOCOCN_LESS_ROWS",
-  "MOCOCN_MORE_ROWS",
-  "OPEN_NEW_WINDOW",
-  "OPEN_PRIVATE_WINDOW",
-  "UNPIN",
-];
-const SOURCES = ["TOP_SITES", "TOP_STORIES"];
+const EVENTS = ["CLICK"];
+const SOURCES = ["CARDGRID", "TOP_SITES", "TOP_STORIES"];
 const TRACKING_BASE = "https://tracking.firefox.com.cn/china-newtab.gif";
 
 const { actionCreators: ac, actionTypes: at } = ChromeUtils.import(

--- a/extension/mozillaonline/parent/ext-chinaNewtab.js
+++ b/extension/mozillaonline/parent/ext-chinaNewtab.js
@@ -79,15 +79,6 @@ this.activityStreamHack = {
     switch (currentVersion) {
       case 0:
         for (let [key, val] of [
-          ["browser.newtabpage.activity-stream.discoverystream.config", JSON.stringify({
-            "collapsible": true,
-            "enabled": false,
-            "show_spocs": false,
-            "hardcoded_layout": false,
-            "personalized": false,
-            "layout_endpoint": "https://newtab.firefoxchina.cn/newtab/ds/china-basic.json",
-          })],
-          ["browser.newtabpage.activity-stream.discoverystream.enabled", false],
           ["browser.newtabpage.activity-stream.discoverystream.endpoints", [
             "https://getpocket.cdn.mozilla.net/",
             "https://spocs.getpocket.com/",
@@ -109,7 +100,6 @@ this.activityStreamHack = {
           ["browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts", false],
           ["browser.newtabpage.activity-stream.section.topstories.rows", 3],
           ["browser.newtabpage.activity-stream.topSitesRows", 2],
-          ["extensions.chinaNewtab.prefVersion", 1],
           // Disable appcache based offlintab from cehomepage
           ["moa.ntab.openInNewTab", false],
         ]) {
@@ -129,7 +119,24 @@ this.activityStreamHack = {
         if (currentVersion === 1) {
           prefsToSet.set("browser.newtabpage.activity-stream.feeds.system.topstories", true);
         }
-        prefsToSet.set("extensions.chinaNewtab.prefVersion", 2);
+
+        // intentionally no break;
+      case 2:
+        // Flip on DiscoveryStream
+        for (let [key, val] of [
+          ["browser.newtabpage.activity-stream.discoverystream.config", JSON.stringify({
+            "collapsible": true,
+            "enabled": true,
+            "show_spocs": false,
+            "hardcoded_layout": false,
+            "personalized": false,
+            "layout_endpoint": "https://newtab.firefoxchina.cn/newtab/ds/china-basic.json",
+          })],
+          ["browser.newtabpage.activity-stream.discoverystream.enabled", true],
+          ["extensions.chinaNewtab.prefVersion", 3],
+        ]) {
+          prefsToSet.set(key, val);
+        }
         break;
       default:
         break;


### PR DESCRIPTION
See MozillaOnline/newtab-web@9db6da5a, this also makes it possible to enable newNewtabExperience on Fx 89+.

For duplicated telemetry events sent to our own metrics server, "CARDGRID" is the DS equivalent of "TOP_STORIES".

Thanks!