### PR TITLE
Replace XPCOMUtils.defineLazyGetter with ChromeUtils.defineLazyGetter

### DIFF
--- a/extension/mozillaonline/parent/ext-chinaNewtab.js
+++ b/extension/mozillaonline/parent/ext-chinaNewtab.js
@@ -447,7 +447,7 @@ this.ntpColors = {
   },
 };
 
-XPCOMUtils.defineLazyGetter(
+ChromeUtils.defineLazyGetter(
   this,
   "remotePages",
   () =>


### PR DESCRIPTION
XPCOMUtils.defineLazyGetter will be removed. See [bug 1820099](https://bugzilla.mozilla.org/show_bug.cgi?id=1820099) for more info