### PR TITLE
Update addon version to major.minor schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "china-newtab",
-  "version": "5.114.0",
+  "version": "5.114",
   "description": "Customizied New Tab Page for Firefox",
   "scripts": {
     "build": "web-ext build --filename china-newtab.xpi",


### PR DESCRIPTION
@mozilla-extensions/releng

This change is needed for https://github.com/mozilla-extensions/xpi-manifest/pull/215

In [Bug 1793925](https://bugzilla.mozilla.org/show_bug.cgi?id=1793925), Firefox Desktop started to emit warnings when an extension's version doesn't match the format specified in the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version#version_format).

To comply with this format, we need to drop the patch version on the add on pipeline web extensions.

The pipeline will now generate versions as `major.minor.date.time`